### PR TITLE
fix: pnpm の実行コマンド修正

### DIFF
--- a/pkg/def-manager/data/buildspecs/operate-env-infra.yml
+++ b/pkg/def-manager/data/buildspecs/operate-env-infra.yml
@@ -52,7 +52,7 @@ phases:
   build:
     commands:
       - echo ==== terraform operation ====
-      - pnpm exec --dir ./pkg/shared ts-node -T ./scripts/operate.ts
+      - pnpm exec ts-node -T ./pkg/shared/scripts/operate-env.ts
       - echo ==== finished ====
   post_build:
     commands:


### PR DESCRIPTION
continuation of https://github.com/violet-ts/violet-infrastructure/pull/21

https://github.com/LumaKernel/violet/pull/5#issuecomment-957339014

```
[Container] 2021/11/02 11:09:29 Command did not exit successfully pnpm exec --dir ./pkg/shared ts-node -T ./scripts/operate.ts exit status 1
--
[Container] 2021/11/02 11:09:29 Phase complete: BUILD State: FAILED
[Container] 2021/11/02 11:09:29 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: pnpm exec --dir ./pkg/shared ts-node -T ./scripts/operate.ts. Reason: exit status 1
```

related: https://github.com/violet-ts/violet-infrastructure/issues/14