### PR TITLE
fix: sharedEnv を operate-env にもちゃんと流す

### DIFF
--- a/pkg/def-env/src/entry.ts
+++ b/pkg/def-env/src/entry.ts
@@ -1,6 +1,5 @@
 import { App } from 'cdktf';
 import { configureBackend } from '@self/shared/lib/def/util/backend';
-import { requireSharedEnvVars } from '@self/shared/lib/def/env-vars';
 import { initEnv } from '@self/shared/lib/def/util/init-env';
 import { computedOpEnvSchema, dynamicOpEnvSchema } from '@self/shared/lib/operate-env/op-env';
 import type { VioletEnvOptions } from './stack';
@@ -8,7 +7,6 @@ import { VioletEnvStack } from './stack';
 
 initEnv();
 
-const sharedEnv = requireSharedEnvVars();
 const dynamicOpEnv = dynamicOpEnvSchema.parse(process.env);
 const computedOpEnv = computedOpEnvSchema.parse(process.env);
 
@@ -16,7 +14,7 @@ const options: VioletEnvOptions = {
   // TODO(hardcoded)
   region: 'ap-northeast-1',
 
-  sharedEnv,
+  sharedEnv: computedOpEnv,
   dynamicOpEnv,
   computedOpEnv,
 

--- a/pkg/def-manager/src/entry.ts
+++ b/pkg/def-manager/src/entry.ts
@@ -1,5 +1,5 @@
 import { App } from 'cdktf';
-import { requireSharedEnvVars, managerEnvSchema } from '@self/shared/lib/def/env-vars';
+import { sharedEnvSchema, managerEnvSchema, extractDockerHubCred } from '@self/shared/lib/def/env-vars';
 import { configureBackend } from '@self/shared/lib/def/util/backend';
 import { initEnv } from '@self/shared/lib/def/util/init-env';
 import type { VioletManagerOptions } from './stack';
@@ -7,14 +7,17 @@ import { VioletManagerStack } from './stack';
 
 initEnv();
 
-const sharedEnv = requireSharedEnvVars();
+const sharedEnv = sharedEnvSchema.parse(process.env);
 const managerEnv = managerEnvSchema.parse(process.env);
+const dockerHubCred = extractDockerHubCred(process.env);
 
 const app = new App();
 const options: VioletManagerOptions = {
   region: 'ap-northeast-1',
   sharedEnv,
   managerEnv,
+
+  dockerHubCred,
 };
 
 const stack = new VioletManagerStack(app, 'violet-infra', options);

--- a/pkg/def-manager/src/stack/dockerhub-credentials.ts
+++ b/pkg/def-manager/src/stack/dockerhub-credentials.ts
@@ -2,11 +2,11 @@ import type { CodeBuild } from '@cdktf/provider-aws';
 import { SecretsManager, IAM } from '@cdktf/provider-aws';
 import type { ResourceConfig } from '@cdktf/provider-null';
 import { Resource } from '@cdktf/provider-null';
-import type { SharedEnv } from '@self/shared/lib/def/env-vars';
+import type { DockerHubCred } from '@self/shared/lib/def/env-vars';
 import type { VioletManagerStack } from '.';
 
 export interface DockerHubCredentialsOptions {
-  DOCKERHUB: Required<SharedEnv>['DOCKERHUB'];
+  dockerHubCred: DockerHubCred;
   prefix: string;
   tagsAll: Record<string, string>;
 }
@@ -39,8 +39,8 @@ export class DockerHubCredentials extends Resource {
   readonly credentialsValue = new SecretsManager.SecretsmanagerSecretVersion(this, 'usernameValue', {
     secretId: this.credentials.id,
     secretString: JSON.stringify({
-      [this.USER_KEY]: this.options.DOCKERHUB.USER,
-      [this.PASS_KEY]: this.options.DOCKERHUB.PASS,
+      [this.USER_KEY]: this.options.dockerHubCred.USER,
+      [this.PASS_KEY]: this.options.dockerHubCred.PASS,
     }),
   });
 

--- a/pkg/def-manager/src/stack/index.ts
+++ b/pkg/def-manager/src/stack/index.ts
@@ -4,7 +4,7 @@ import { RandomProvider, String as RandomString } from '@cdktf/provider-random';
 import { TerraformOutput, TerraformStack, TerraformHclModule } from 'cdktf';
 import type { Construct } from 'constructs';
 import { PROJECT_NAME } from '@self/shared/lib/const';
-import type { ManagerEnv, SharedEnv } from '@self/shared/lib/def/env-vars';
+import type { DockerHubCred, ManagerEnv, SharedEnv } from '@self/shared/lib/def/env-vars';
 import { Bot } from './bot';
 import { ContainerBuild } from './build-container';
 import { DockerHubCredentials } from './dockerhub-credentials';
@@ -15,6 +15,8 @@ export interface VioletManagerOptions {
   region: string;
   sharedEnv: SharedEnv;
   managerEnv: ManagerEnv;
+
+  dockerHubCred?: DockerHubCred | undefined;
 }
 
 export class VioletManagerStack extends TerraformStack {
@@ -86,18 +88,16 @@ export class VioletManagerStack extends TerraformStack {
     },
   });
 
-  readonly dockerHubCredentials = (() => {
-    const { DOCKERHUB } = this.options.sharedEnv;
-    if (DOCKERHUB == null) return null;
-    return new DockerHubCredentials(this, 'dockerHubCredentials', {
-      DOCKERHUB,
+  readonly dockerHubCredentials =
+    this.options.dockerHubCred &&
+    new DockerHubCredentials(this, 'dockerHubCredentials', {
+      dockerHubCred: this.options.dockerHubCred,
       prefix: 'violet',
 
       tagsAll: {
         ...genTags(null),
       },
     });
-  })();
 
   readonly ssmPrefix = `/${PROJECT_NAME}-${this.suffix.result}`;
 

--- a/pkg/def-manager/src/stack/operate-env.ts
+++ b/pkg/def-manager/src/stack/operate-env.ts
@@ -102,6 +102,7 @@ export class OperateEnv extends Resource {
   });
 
   readonly computedOpEnv: ComputedOpEnv = {
+    ...this.parent.options.sharedEnv,
     INFRA_GIT_URL: this.parent.options.sharedEnv.INFRA_GIT_URL,
     INFRA_GIT_FETCH: this.parent.options.sharedEnv.INFRA_GIT_FETCH,
     API_REPO_NAME: this.parent.apiDevRepo.name,

--- a/pkg/shared/lib/def/env-vars.ts
+++ b/pkg/shared/lib/def/env-vars.ts
@@ -1,45 +1,32 @@
 import { z } from 'zod';
-import { requireEnv } from '@self/shared/lib/util/env';
+
+const dockerHubCredSchema = z.object({
+  USER: z.string(),
+  PASS: z.string(),
+});
+export type DockerHubCred = z.infer<typeof dockerHubCredSchema>;
+export const extractDockerHubCred = (from: Record<string, string | undefined>): DockerHubCred | undefined => {
+  const { DOCKERHUB_USER, DOCKERHUB_PASS } = from;
+  if ((typeof DOCKERHUB_USER !== 'string') !== (typeof DOCKERHUB_PASS !== 'string'))
+    throw new Error('both DOCKERHUB_USER and DOCKERHUB_PASS should either exist or be absent');
+  const dockerHubCred =
+    typeof DOCKERHUB_USER === 'string' && typeof DOCKERHUB_PASS === 'string'
+      ? { USER: DOCKERHUB_USER, PASS: DOCKERHUB_PASS }
+      : undefined;
+
+  return dockerHubCred;
+};
 
 export const sharedEnvSchema = z.object({
   AWS_ACCOUNT_ID: z.string(),
   AWS_PROFILE: z.optional(z.string()),
   /** 事前に作成した AWS Route53 Zone */
   PREVIEW_ZONE_ID: z.string(),
-  DOCKERHUB: z.optional(
-    z.object({
-      USER: z.string(),
-      PASS: z.string(),
-    }),
-  ),
   INFRA_GIT_URL: z.string(),
   INFRA_GIT_FETCH: z.string(),
 });
-
 // ローカルからのみ与えることが可能
 export type SharedEnv = z.infer<typeof sharedEnvSchema>;
-export const requireSharedEnvVars = (): SharedEnv => {
-  const { AWS_PROFILE, DOCKERHUB_USER, DOCKERHUB_PASS } = process.env;
-  const { AWS_ACCOUNT_ID } = requireEnv('AWS_ACCOUNT_ID');
-  const { INFRA_GIT_URL } = requireEnv('INFRA_GIT_URL');
-  const { INFRA_GIT_FETCH } = requireEnv('INFRA_GIT_FETCH');
-  if ((typeof DOCKERHUB_USER !== 'string') !== (typeof DOCKERHUB_PASS !== 'string'))
-    throw new Error('both DOCKERHUB_USER and DOCKERHUB_PASS should either exist or be absent');
-  const DOCKERHUB =
-    typeof DOCKERHUB_USER === 'string' && typeof DOCKERHUB_PASS === 'string'
-      ? { USER: DOCKERHUB_USER, PASS: DOCKERHUB_PASS }
-      : undefined;
-  const { PREVIEW_ZONE_ID } = requireEnv('PREVIEW_ZONE_ID');
-
-  return {
-    AWS_ACCOUNT_ID,
-    AWS_PROFILE,
-    PREVIEW_ZONE_ID,
-    DOCKERHUB,
-    INFRA_GIT_URL,
-    INFRA_GIT_FETCH,
-  };
-};
 
 export const managerEnvSchema = z.object({
   CIDR_NUM: z.string().regex(/[0-9]+/),

--- a/pkg/shared/lib/operate-env/op-env.ts
+++ b/pkg/shared/lib/operate-env/op-env.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { sharedEnvSchema } from '../def/env-vars';
 import type { CodeBuildEnv } from '../util/aws-cdk';
 import { toCodeBuildEnv } from '../util/aws-cdk';
 
@@ -44,27 +45,26 @@ export type DynamicOpEnv = z.infer<typeof dynamicOpEnvSchema>;
 export const dynamicOpCodeBuildEnv = (env: DynamicOpEnv): CodeBuildEnv => toCodeBuildEnv<DynamicOpEnv>(env);
 
 // computed: Manager 環境を作ったときに自動で計算して固定して設定する
-export const computedOpEnvSchema = z.object({
-  INFRA_GIT_URL: z.string(),
-  INFRA_GIT_FETCH: z.string(),
-  API_REPO_NAME: z.string(),
-  WEB_REPO_NAME: z.string(),
-  AWS_ACCOUNT_ID: z.string(),
-  S3BACKEND_REGION: z.string(),
-  S3BACKEND_BUCKET: z.string(),
-  S3BACKEND_PREFIX: z.optional(z.string()),
-  NETWORK_VPC_ID: z.string(),
-  NETWORK_DB_SG_ID: z.string(),
-  NETWORK_LB_SG_ID: z.string(),
-  NETWORK_SVC_SG_ID: z.string(),
-  NETWORK_PRIV_ID0: z.string(),
-  NETWORK_PRIV_ID1: z.string(),
-  NETWORK_PRIV_ID2: z.string(),
-  NETWORK_PUB_ID0: z.string(),
-  NETWORK_PUB_ID1: z.string(),
-  NETWORK_PUB_ID2: z.string(),
-  OPERATE_ENV_ROLE_NAME: z.string(),
-});
+export const computedOpEnvSchema = z
+  .object({
+    API_REPO_NAME: z.string(),
+    WEB_REPO_NAME: z.string(),
+    S3BACKEND_REGION: z.string(),
+    S3BACKEND_BUCKET: z.string(),
+    S3BACKEND_PREFIX: z.optional(z.string()),
+    NETWORK_VPC_ID: z.string(),
+    NETWORK_DB_SG_ID: z.string(),
+    NETWORK_LB_SG_ID: z.string(),
+    NETWORK_SVC_SG_ID: z.string(),
+    NETWORK_PRIV_ID0: z.string(),
+    NETWORK_PRIV_ID1: z.string(),
+    NETWORK_PRIV_ID2: z.string(),
+    NETWORK_PUB_ID0: z.string(),
+    NETWORK_PUB_ID1: z.string(),
+    NETWORK_PUB_ID2: z.string(),
+    OPERATE_ENV_ROLE_NAME: z.string(),
+  })
+  .merge(sharedEnvSchema);
 
 export type ComputedOpEnv = z.infer<typeof computedOpEnvSchema>;
 


### PR DESCRIPTION
- ローカルでは直接流せていたが、CodeBuild環境まで流れていなかった
- ComputedOp に merge させて流す。
- DockerHubCred は分割され、リファクタされてきれいになった。

related: https://github.com/violet-ts/violet-infrastructure/issues/14

continuation of をPRに書くのはめんどいので廃止、上記issueで確認できる。

https://github.com/LumaKernel/violet/pull/5#issuecomment-957364511