### PR TITLE
fix: AWS_PROFILE は流さない、管理しない

### DIFF
--- a/pkg/def-env/src/stack/index.ts
+++ b/pkg/def-env/src/stack/index.ts
@@ -46,7 +46,7 @@ export class VioletEnvStack extends TerraformStack {
 
   readonly aws = new AwsProvider(this, 'aws', {
     region: this.options.region,
-    profile: this.options.sharedEnv.AWS_PROFILE,
+    profile: process.env.AWS_PROFILE || undefined,
     defaultTags: {
       tags: genTags(null, this.options.dynamicOpEnv.NAMESPACE, this.options.section),
     },

--- a/pkg/def-manager/src/stack/index.ts
+++ b/pkg/def-manager/src/stack/index.ts
@@ -34,7 +34,7 @@ export class VioletManagerStack extends TerraformStack {
 
   readonly awsProvider = new AwsProvider(this, 'awsProvider', {
     region: this.options.region,
-    profile: this.options.sharedEnv.AWS_PROFILE,
+    profile: process.env.AWS_PROFILE || undefined,
     defaultTags: {
       tags: genTags(null),
     },

--- a/pkg/shared/lib/def/env-vars.ts
+++ b/pkg/shared/lib/def/env-vars.ts
@@ -19,7 +19,6 @@ export const extractDockerHubCred = (from: Record<string, string | undefined>): 
 
 export const sharedEnvSchema = z.object({
   AWS_ACCOUNT_ID: z.string(),
-  AWS_PROFILE: z.optional(z.string()),
   /** 事前に作成した AWS Route53 Zone */
   PREVIEW_ZONE_ID: z.string(),
   INFRA_GIT_URL: z.string(),


### PR DESCRIPTION
process.env から直接使用

related: https://github.com/violet-ts/violet-infrastructure/issues/14