### PR TITLE
dynamodb の権限修正とインフラ定義を信頼できるコミットのみに限定

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,30 +1,36 @@
-## すべてローカル実行で必要。一部は本来 CodeBuild でデプロイするのをローカルでやるのに必要。
-
-## shared
-AWS_ACCOUNT_ID=111111111111
-PREVIEW_ZONE_ID=...
-# DOCKERHUB_USER=...
-# DOCKERHUB_PASS=...
-
-## dynamic op
+## [required for local op-env] dynamic op
 NAMESPACE=local
 CIDR_NUM=0
-API_REPO_NAME=...
 API_REPO_SHA=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+WEB_REPO_SHA=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
-## computed op
+## [required for local op-env] computed op
 # manager stack の tf 出力 opEnvFile にまとめてある
 
-## ローカルで使う際に必要
-## - AWS Provider の設定
-# AWS_PROFILE=violet
-## - script op
-ENTRY_UUID=dummy
-
-## - AWS Backend の設定
+## [required] AWS Backend の設定
+AWS_PROFILE=violet
 ## TODO(hardcoded): backend は現状 S3 で決め打ち
 # S3BACKEND_REGION=...
 # S3BACKEND_BUCKET=...
 # S3BACKEND_PROFILE=...
 # S3BACKEND_PREFIX=...
+
+## [required for local op-env] ローカルで operate-env を使う際に必要
+## - AWS Provider の設定
+## - script op
+ENTRY_UUID=dummy
+
+## [required] shared
+AWS_ACCOUNT_ID=111111111111
+PREVIEW_ZONE_ID=...
+## - 注意: 信用できないリポジトリは使わない
+## - GitHub 上で信頼できるメアドの使用者でマージ(rebase以外)されてる場合のみ使用可能
+INFRA_GIT_URL=https://github.com/violet-ts/violet-infrastructure.git
+INFRA_GIT_FETCH=main
+## - コンマ区切りの信頼できるメアド
+INFRA_TRUSTED_MERGER_GITHUB_EMAILS=world@luma.email,solufa2020@gmail.com
+
+## [optional for manager] DockerHub からの pull 制限緩和
+# DOCKERHUB_USER=...
+# DOCKERHUB_PASS=...
 

--- a/pkg/bot/src/cmd/template/operate-env.ts
+++ b/pkg/bot/src/cmd/template/operate-env.ts
@@ -75,7 +75,6 @@ const createCmd = (
           environmentVariablesOverride: [
             ...scriptOpCodeBuildEnv({
               OPERATION: paramsGetter(ctx.env).operation,
-              BOT_TABLE_NAME: ctx.env.BOT_TABLE_NAME,
               ENTRY_UUID: generalEntry.uuid,
             }),
             ...dynamicOpCodeBuildEnv({

--- a/pkg/def-manager/data/buildspecs/operate-env-infra.yml
+++ b/pkg/def-manager/data/buildspecs/operate-env-infra.yml
@@ -23,11 +23,16 @@ phases:
       - echo ==== install pnpm ====
       - npm i -g "pnpm@${PNPM_VERSION}"
       - pnpm --version
+      - echo ==== download GitHub GPG public key ====
+      - export GH_GPG_PUB_FILE="$(pwd)/github-web-flow.gpg"
+      - curl https://github.com/web-flow.gpg -o "$GH_GPG_PUB_FILE"
+      - gpg --import "$GH_GPG_PUB_FILE"
       - echo ==== environment variables ====
       - echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"
       - echo "AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID"
       - echo "INFRA_GIT_URL=$INFRA_GIT_URL"
       - echo "INFRA_GIT_FETCH=$INFRA_GIT_FETCH"
+      - echo "INFRA_TRUSTED_MERGER_GITHUB_EMAILS=$INFRA_TRUSTED_MERGER_GITHUB_EMAILS"
       - echo ==== info ====
       - pwd
       - whoami
@@ -44,6 +49,37 @@ phases:
       - git remote add origin "$INFRA_GIT_URL"
       - git fetch origin "$INFRA_GIT_FETCH"
       - git checkout FETCH_HEAD
+      - echo ==== git commit verify ====
+      - git show -s HEAD
+      - 'echo "INFO: Check whether signed by GitHub GPG."'
+      - test "$(git show -s --format='%GP' HEAD)" = "5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23"
+      - git verify-commit HEAD
+      - export AUTHOR_EMAIL="$(git show -s --format='%ae' HEAD)"
+      - echo "AUTHOR_EMAIL=$AUTHOR_EMAIL"
+      - 'echo "INFO: Check whether the inputs are 1 line string."'
+      - test "$(echo "$INFRA_TRUSTED_MERGER_GITHUB_EMAILS" | wc -l)" = 1
+      - test "$(echo "$AUTHOR_EMAIL" | wc -l)" = 1
+      - 'echo "INFO: Verify the email is in trusted list."'
+      - 'echo "INFO: List is separated by commas."'
+      - |
+        awk '
+          NR == 1 {
+            split($0, emails, ",")
+          }
+          NR == 2 {
+            author_email = $0
+          }
+          END {
+            for (i=1; i in emails; i++) {
+              if (author_email == emails[i]) {
+                print "ok"
+                exit 0
+              }
+            }
+            print "no email matched"
+            exit 1
+          }
+        ' <(echo "$INFRA_TRUSTED_MERGER_GITHUB_EMAILS") <(echo "$AUTHOR_EMAIL")
       - echo ==== pnpm store status ====
       - pnpm store status || true
       - echo ==== pnpm install ====

--- a/pkg/def-manager/src/stack/build-container.ts
+++ b/pkg/def-manager/src/stack/build-container.ts
@@ -41,7 +41,7 @@ export class ContainerBuild extends Resource {
     special: false,
   });
 
-  // TODO
+  // TODO: https://github.com/hashicorp/terraform-provider-aws/issues/10195
   readonly cachename = `${this.options.prefix}-cache`;
 
   // TODO(cost): lifecycle
@@ -220,7 +220,7 @@ export class ContainerBuild extends Resource {
     name: `${this.options.prefix}-${this.suffix.result}`,
     resource: this.build.arn,
     detailType: 'BASIC',
-    // https://docs.aws.amazon.com/ja_jp/dtconsole/latest/userguide/concepts.html#concepts-api
+    // https://docs.aws.amazon.com/dtconsole/latest/userguide/concepts.html#concepts-api
     eventTypeIds: [
       'codebuild-project-build-state-failed',
       'codebuild-project-build-state-succeeded',

--- a/pkg/def-manager/src/stack/operate-env.ts
+++ b/pkg/def-manager/src/stack/operate-env.ts
@@ -106,6 +106,7 @@ export class OperateEnv extends Resource {
     ...this.parent.options.sharedEnv,
     INFRA_GIT_URL: this.parent.options.sharedEnv.INFRA_GIT_URL,
     INFRA_GIT_FETCH: this.parent.options.sharedEnv.INFRA_GIT_FETCH,
+    INFRA_TRUSTED_MERGER_GITHUB_EMAILS: this.parent.options.sharedEnv.INFRA_TRUSTED_MERGER_GITHUB_EMAILS,
     API_REPO_NAME: this.parent.apiDevRepo.name,
     WEB_REPO_NAME: this.parent.webDevRepo.name,
     AWS_ACCOUNT_ID: this.parent.options.sharedEnv.AWS_ACCOUNT_ID,

--- a/pkg/shared/lib/def/env-vars.ts
+++ b/pkg/shared/lib/def/env-vars.ts
@@ -23,6 +23,7 @@ export const sharedEnvSchema = z.object({
   PREVIEW_ZONE_ID: z.string(),
   INFRA_GIT_URL: z.string(),
   INFRA_GIT_FETCH: z.string(),
+  INFRA_TRUSTED_MERGER_GITHUB_EMAILS: z.string(),
 });
 // ローカルからのみ与えることが可能
 export type SharedEnv = z.infer<typeof sharedEnvSchema>;

--- a/pkg/shared/lib/operate-env/op-env.ts
+++ b/pkg/shared/lib/operate-env/op-env.ts
@@ -20,7 +20,6 @@ export const scriptOpEnvSchema = z.object({
     z.literal('prisma/migrate/status'), // TODO: wip
     z.literal('prisma/db/seed'),
   ]),
-  BOT_TABLE_NAME: z.string(),
   ENTRY_UUID: z.string(),
 });
 
@@ -63,6 +62,7 @@ export const computedOpEnvSchema = z
     NETWORK_PUB_ID1: z.string(),
     NETWORK_PUB_ID2: z.string(),
     OPERATE_ENV_ROLE_NAME: z.string(),
+    BOT_TABLE_NAME: z.string(),
   })
   .merge(sharedEnvSchema);
 

--- a/pkg/shared/scripts/operate-env.ts
+++ b/pkg/shared/scripts/operate-env.ts
@@ -23,7 +23,7 @@ const main = async () => {
 
   // TODO(hardcoded)
   const botTableRegion = 'ap-northeast-1';
-  const entryURL = `https://${botTableRegion}.console.aws.amazon.com/dynamodbv2/home#item-explorer?autoScanAttribute=null&initialTagKey=&table=${scriptOpEnv.BOT_TABLE_NAME}`;
+  const entryURL = `https://${botTableRegion}.console.aws.amazon.com/dynamodbv2/home#item-explorer?autoScanAttribute=null&initialTagKey=&table=${computedOpEnv.BOT_TABLE_NAME}`;
 
   const delay = (ms: number): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
@@ -40,7 +40,7 @@ const main = async () => {
     // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html
     await db
       .updateItem({
-        TableName: scriptOpEnv.BOT_TABLE_NAME,
+        TableName: computedOpEnv.BOT_TABLE_NAME,
         Key: {
           uuid: { S: scriptOpEnv.ENTRY_UUID },
         },


### PR DESCRIPTION
- fix: BOT_TABLE_NAME を Computed Op に入れて dynamodb update 権限を op に設定、他コメント修正
- fix(security): インフラ定義を信頼できるマージ者によるもののみを実行するように

related: https://github.com/violet-ts/violet-infrastructure/issues/14
related: https://github.com/violet-ts/violet-infrastructure/issues/20
