### PR TITLE
fix(codebuild): デフォルトで /bin/sh で process substitution が動いていなかった

### DIFF
--- a/pkg/def-manager/data/buildspecs/build-container.yml
+++ b/pkg/def-manager/data/buildspecs/build-container.yml
@@ -1,5 +1,8 @@
 version: 0.2
 
+env:
+  shell: bash
+
 phases:
   install:
     commands:

--- a/pkg/def-manager/data/buildspecs/operate-env-infra.yml
+++ b/pkg/def-manager/data/buildspecs/operate-env-infra.yml
@@ -5,6 +5,7 @@ env:
     TERRAFORM_VERSION: "1.0.9"
     PNPM_VERSION: "6"
     HUSKY: "0"
+  shell: bash
 
 phases:
   install:


### PR DESCRIPTION
- bash へ変更
- related: https://github.com/LumaKernel/violet/pull/5#issuecomment-958629123
- doc: https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec.shell
