### PR TITLE
fix: urlencode db url for prisma

### DIFF
--- a/pkg/def-env/src/stack/index.ts
+++ b/pkg/def-env/src/stack/index.ts
@@ -155,7 +155,7 @@ export class VioletEnvStack extends TerraformStack {
     env: {
       API_BASE_PATH: '',
       // TODO(security): SecretsManager 使いたい
-      DATABASE_URL: z.string().parse(this.dbURL.value),
+      DATABASE_URL: `urlencode(${z.string().parse(this.dbURL.value)})`,
       S3_BUCKET: z.string().parse(this.s3.bucket),
       S3_REGION: this.s3.region,
     },


### PR DESCRIPTION
https://www.prisma.io/docs/reference/database-reference/connection-urls#special-characters

> Special characters
For MySQL and PostgreSQL, you must percentage-encode special characters in any part of your connection URL - including passwords. For example, p@$$w0rd becomes p%40%24%24w0rd.

https://www.terraform.io/docs/language/functions/urlencode.html